### PR TITLE
fix include invocations in test file

### DIFF
--- a/test/test-baroque.ly
+++ b/test/test-baroque.ly
@@ -1,5 +1,5 @@
 \version "2.15.20"
-\include "../baroque.ily"
+\include "../nenuvar-baroque.ily"
 
 {
   c'' \cesure c'' \cesureCenter c'' \cesureDown c'' \cesureInstr

--- a/test/test-clef.ly
+++ b/test/test-clef.ly
@@ -1,10 +1,10 @@
 \version "2.19.37"
-\include "../clef.ily"
+\include "../nenuvar-clef.ily"
 
 #(ly:set-option 'use-ancient-clef #t)
 \markup\bold "Ancient clefs"
 \markup "Expected:"
-{ \clef "french" c'1 
+{ \clef "french" c'1
   \clef "petrucci-g" c'1
   \clef "petrucci-c1" c'1
   \clef "petrucci-c2" c'1
@@ -14,7 +14,7 @@
   \clef "petrucci-f" c'1
   \clef "petrucci-c5" c'1 }
 \markup "Obtained:"
-{ \clef "dessus" c'1 
+{ \clef "dessus" c'1
   \clef "petrucci-g/treble" c'1
   \clef "petrucci-c1/treble" c'1
   \clef "petrucci-c2/treble" c'1
@@ -27,7 +27,7 @@
 #(ly:set-option 'use-ancient-clef #f)
 \markup\bold "Modern clefs"
 \markup "Expected:"
-{ \clef "treble" c'1 
+{ \clef "treble" c'1
   \clef "treble" c'1
   \clef "treble" c'1
   \clef "treble" c'1
@@ -37,7 +37,7 @@
   \clef "bass" c'1
   \clef "bass" c'1 }
 \markup "Obtained:"
-{ \clef "dessus" c'1 
+{ \clef "dessus" c'1
   \clef "petrucci-g/treble" c'1
   \clef "petrucci-c1/treble" c'1
   \clef "petrucci-c2/treble" c'1
@@ -49,7 +49,7 @@
 
 #(ly:set-option 'show-ancient-clef #t)
 \markup\bold "Ancient and modern clefs (without parentheses)"
-{ \clef "dessus" c'1 
+{ \clef "dessus" c'1
   \clef "petrucci-g/treble" c'1
   \clef "petrucci-c1/treble" c'1
   \clef "petrucci-c2/treble" c'1

--- a/test/test-livret.ly
+++ b/test/test-livret.ly
@@ -1,8 +1,8 @@
 \version "2.19.37"
 
-\include "../text-formatting.ily"
-\include "../columns.ily"
-\include "../livret.ily"
+\include "../nenuvar-text-formatting.ily"
+\include "../nenuvar-columns.ily"
+\include "../nenuvar-livret.ily"
 
 #(set-global-staff-size 16)
 

--- a/test/test-titling.ly
+++ b/test/test-titling.ly
@@ -1,9 +1,9 @@
 \version "2.11.39"
-\include "../fancy-headers.ily"
-\include "../includes.ily"
-\include "../toc-columns.ily"
-\include "../titling.ily"
-\include "../text-formatting.ily"
+\include "../nenuvar-fancy-headers.ily"
+\include "../nenuvar-includes.ily"
+\include "../nenuvar-toc-columns.ily"
+\include "../nenuvar-titling.ily"
+\include "../nenuvar-text-formatting.ily"
 
 #(format #t "~%~s" (rehearsal-number))
 

--- a/test/test-toc-columns.ly
+++ b/test/test-toc-columns.ly
@@ -1,6 +1,6 @@
 \version "2.13.54"
 
-\include "../toc-columns.ily"
+\include "../nenuvar-toc-columns.ily"
 
 %%% Rehearsal numbers
 #(define-public rehearsal-number #f)
@@ -11,25 +11,25 @@
         (lambda ()
           (set! major-number (1+ major-number))
           (set! minor-number 0)))
-  (set! rehearsal-number 
+  (set! rehearsal-number
         (lambda ()
           (set! minor-number (1+ minor-number))
           (format #f "~a-~a" major-number minor-number))))
 
-tocItem = 
+tocItem =
 #(define-music-function (parser location text) (markup?)
    "Add a line to the table of content, using the @code{tocItemMarkup} paper
 variable markup"
   (let ((rehearsal (rehearsal-number)))
    (add-toc-item! 'tocPieceMarkup text rehearsal)))
 
-tocSceneItem = 
+tocSceneItem =
 #(define-music-function (parser location text) (markup?)
    "Add a line to the table of content, using the @code{tocItemMarkup} paper
 variable markup"
    (add-toc-item! 'tocSceneMarkup text))
 
-tocActItem = 
+tocActItem =
 #(define-music-function (parser location text) (markup?)
    "Add a line to the table of content, using the @code{tocItemMarkup} paper
 variable markup"


### PR DESCRIPTION
Test files contained includes that did not match. I have updated them.
Now test files compile without warnings and errors

This commit also deletes trailing spaces in test files.